### PR TITLE
v0.1.7: Module dependency / doc fixes

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,25 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+python:
+  install:
+    - method: pip
+      path: .
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+    # You can also specify other tool versions:
+    # nodejs: "19"
+    # rust: "1.64"
+    # golang: "1.19"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+   configuration: docs/conf.py

--- a/README.md
+++ b/README.md
@@ -47,4 +47,9 @@ In [4]: print(amdgpu_stats.utils.get_temp_stats())
 In [5]: print(amdgpu_stats.utils.get_fan_stats())
 {'fan_rpm': 0, 'fan_rpm_target': 0}
 ```
-See `help('amdgpu_stats.utils')` or [the module source](https://github.com/joshlay/amdgpu_stats/blob/master/src/amdgpu_stats/utils.py) for more info
+## Documentation
+
+For more information on the module, see:
+ - `help('amdgpu_stats.utils')` in your interpreter
+ - [ReadTheDocs](https://amdgpu-stats.readthedocs.io/en/latest/)
+ - [the module source](https://github.com/joshlay/amdgpu_stats/blob/master/src/amdgpu_stats/utils.py) for more info

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "amdgpu-stats"
-version = "0.1.6"
+version = "0.1.7"
 description = "A simple module/TUI (using Textual) that provides AMD GPU statistics"
 authors = ["Josh Lay <pypi@jlay.io>"]
 repository = "https://github.com/joshlay/amdgpu_stats"
@@ -11,10 +11,10 @@ readme = "README.md"
 python = "^3.9"
 textual = ">=0.10"
 humanfriendly = ">=10.0"
-sphinx = "^6.2"
+sphinx = "^5.3"
 
 [tool.poetry.dev-dependencies]
-sphinx-rtd-theme = ">=1.0.0"
+sphinx-rtd-theme = ">=1.1.0"
 
 [tool.poetry.scripts]
 amdgpu-stats = "amdgpu_stats.interface:tui"


### PR DESCRIPTION
Re-releasing [v0.1.6](https://github.com/joshlay/amdgpu_stats/releases/tag/v0.1.6) with fixed `Sphinx` dependencies matching those on Fedora 38

Also attempting to fix documentation on RTD; specifying the `pip` installation method and a more modern Python environment.