### PR TITLE
v0.1.8: add doc link to package (no GH release)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,12 @@
 [tool.poetry]
 name = "amdgpu-stats"
-version = "0.1.7"
+version = "0.1.8"
 description = "A simple module/TUI (using Textual) that provides AMD GPU statistics"
 authors = ["Josh Lay <pypi@jlay.io>"]
 repository = "https://github.com/joshlay/amdgpu_stats"
 license = "MIT"
 readme = "README.md"
+documentation = "https://amdgpu-stats.readthedocs.io/en/latest/"
 
 [tool.poetry.dependencies]
 python = "^3.9"


### PR DESCRIPTION
Documentation only update/'release' (on PyPi/RDT)