### PR TITLE
add card validating/selecting function

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,35 +1,22 @@
 # amdgpu_stats
 
-A simple Python module/TUI _(using [Textual](https://textual.textualize.io/))_ that shows AMD GPU statistics
+A simple Python module/TUI for AMD GPU statistics
 
 ![Screenshot of main screen](https://raw.githubusercontent.com/joshlay/amdgpu_stats/master/screens/main.png "Main screen")
 
-The GPU and temperature nodes (`edge`/`junction`/etc.) are discovered automatically.
-
-Please see [the module section](#module) or [the docs](https://amdgpu-stats.readthedocs.io/en/latest/) for information on usage as an `import` in other tooling
+Supported GPUs and temperature nodes (`edge`/`junction`/etc.) are discovered automatically.
 
 Tested _only_ on `RX6000` series cards; APUs and more _may_ be supported. Please file an issue if finding incompatibility!
 
-## Requirements
-Only `Linux` is supported. Information is _completely_ sourced from interfaces in `sysfs`.
-
-It _may_ be necessary to update the `amdgpu.ppfeaturemask` parameter to enable metrics.
-
-This is assumed present for *control* over the elements being monitored. Untested without. 
-
-See [this Arch Wiki entry](https://wiki.archlinux.org/title/AMDGPU#Boot_parameter) for context.
-
-## Installation / Usage
+## Installation
 ```
 pip install amdgpu-stats
 ```
-Once installed, run `amdgpu-stats` in your terminal of choice
+To use the _TUI_, run `amdgpu-stats` in your terminal of choice. For the _module_, see below!
 
 ## Module
 
-*Rudimentary* support as a module exists; functions / variables offered can be found in `amdgpu_stats.utils`
-
-Demonstration:
+Introduction:
 ```
 In [1]: import amdgpu_stats.utils
 
@@ -39,14 +26,22 @@ Out[2]: {'card0': '/sys/class/drm/card0/device/hwmon/hwmon9'}
 In [3]: amdgpu_stats.utils.get_core_stats('card0')
 Out[3]: {'sclk': 640000000, 'mclk': 1000000000, 'voltage': 0.79, 'util_pct': 65}
 
-In [4]: amdgpu_stats.utils.get_clock('card0', 'core', format_freq=True)
+In [4]: amdgpu_stats.utils.get_clock('core', format_freq=True)
 Out[4]: '659 MHz' 
 ```
+
+For more information on what the module provides, please see:
+ - [ReadTheDocs](https://amdgpu-stats.readthedocs.io/en/latest/)
+ - `help('amdgpu_stats.utils')` in your interpreter
+ - [The module source](https://github.com/joshlay/amdgpu_stats/blob/master/src/amdgpu_stats/utils.py)
+
 Feature requests [are encouraged](https://github.com/joshlay/amdgpu_stats/issues) :)
 
-## Documentation
+## Requirements
+Only `Linux` is supported. Information is _completely_ sourced from interfaces in `sysfs`.
 
-For more information on the module, see:
- - `help('amdgpu_stats.utils')` in your interpreter
- - [ReadTheDocs](https://amdgpu-stats.readthedocs.io/en/latest/)
- - [the module source](https://github.com/joshlay/amdgpu_stats/blob/master/src/amdgpu_stats/utils.py) for more info
+It _may_ be necessary to update the `amdgpu.ppfeaturemask` parameter to enable metrics.
+
+This is assumed present for *control* over the elements being monitored. Untested without. 
+
+See [this Arch Wiki entry](https://wiki.archlinux.org/title/AMDGPU#Boot_parameter) for context.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "amdgpu-stats"
-version = "0.1.9"
-description = "A simple module/TUI (using Textual) that provides AMD GPU statistics"
+version = "0.1.10"
+description = "A simple module/TUI for AMD GPU statistics"
 authors = ["Josh Lay <pypi@jlay.io>"]
 repository = "https://github.com/joshlay/amdgpu_stats"
 license = "MIT"


### PR DESCRIPTION
Make the module more approachable; don't _require_ `card` be set, but allow it

Default behavior (`card` not specified) will be to use the first AMD GPU found

_If_ specified, the vendor will be checked