### PR TITLE
tui: misc fixes - var/comments

### DIFF
--- a/src/amdgpu_stats/tui.py
+++ b/src/amdgpu_stats/tui.py
@@ -155,8 +155,8 @@ class MiscDisplay(Static):
     fan_rpm = reactive(0)
     fan_rpm_target = reactive(0)
     # do some dancing to craft the UI; initialize the reactive obj with data
-    # to get proper labels
     # dynamic object for temperature updates
+    # populated / looped in '__init__' to get proper labels
     temp_stats = reactive({})
     # default to 'not composed', once labels are made - become true
     # avoids a race condition between discovering temperature nodes/stats

--- a/src/amdgpu_stats/tui.py
+++ b/src/amdgpu_stats/tui.py
@@ -167,13 +167,12 @@ class MiscDisplay(Static):
         super().__init__(*args, **kwargs)
         self.timer_misc = None
         self.card = card
-        self.initial_stats = get_temp_stats(self.card)
         self.temp_stats = get_temp_stats(self.card)
 
     def compose(self) -> ComposeResult:
         yield Horizontal(Label("[underline]Temperatures"),
                          Label("", classes="statvalue"))
-        for temp_node in self.initial_stats:
+        for temp_node in self.temp_stats:
             # capitalize the first letter for display
             caption = temp_node[0].upper() + temp_node[1:]
             yield Horizontal(Label(f' {caption}:',),


### PR DESCRIPTION
When dynamically adding labels, we were getting the stats twice unnecessarily -- removing one

Also touching up comments around them slightly