### PR TITLE
rtd: fix docs, add requirements

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,6 +7,7 @@ version: 2
 
 python:
   install:
+    - requirements: docs/requirements.txt
     - method: pip
       path: .
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,2 @@
+sphinx_rtd_theme
+readthedocs-sphinx-search


### PR DESCRIPTION
Building docs was failing with this:
```python
Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/amdgpu-stats/envs/stable/lib/python3.11/site-packages/sphinx/registry.py", line 447, in load_extension
    mod = import_module(extname)
          ^^^^^^^^^^^^^^^^^^^^^^
  File "/home/docs/.asdf/installs/python/3.11.6/lib/python3.11/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1204, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1176, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1140, in _find_and_load_unlocked
ModuleNotFoundError: No module named 'sphinx_rtd_theme'
```
Adding/using requirements should help